### PR TITLE
Some best practices

### DIFF
--- a/archinstall.sh
+++ b/archinstall.sh
@@ -14,23 +14,23 @@ HOST="archbox"
 
 ### PARTITIONING ###
 #for MBR/GRUB - legacy bios
-#parted --script $HDD \
+#parted --script ${HDD} \
 #	mklabel msdos \
 #	mkpart primary ext4 1MiB 100% \
 #  set 1 boot on
 
 #for GPT/GRUB - UEFI
-parted --script $HDD \
+parted --script ${HDD} \
 	mklabel gpt \
 	mkpart P1 fat32 1MiB 512MiB  \
 	mkpart primary ext4 1500MiB 7000MiB
 
 
 # formating the partitions
-mkfs.ext4 $ROOTPART
+mkfs.ext4 ${ROOTPART}
 
 # mount the partitions
-mount $ROOTPART /mnt
+mount ${ROOTPART} /mnt
 
 # TODO: automatically set austria server to the default server
 # https://wiki.archlinux.org/index.php/Mirrors#Sorting_mirrors
@@ -46,7 +46,7 @@ genfstab -U /mnt >> /mnt/etc/fstab
 # chroot into the installed system
 arch-chroot /mnt ln -sf /usr/share/zoneinfo/Europe/Vienna /etc/localtime
 arch-chroot /mnt hwclock --systohc
-echo $HOST > /mnt/etc/hostname
+echo ${HOST} > /mnt/etc/hostname
 cat >> /mnt/etc/hosts <<EOF
 127.0.0.1 localhost
 ::1       localhost
@@ -84,6 +84,6 @@ arch-chroot systemctl enable dhcpcd
 # bootloader
 #arch-chroot pacman -S grub efibootmgr dosfstools os-prober mtools
 #arch-chroot mkdir /boot/EFI
-#arch-chroot mount /dev/$ROOTPART1 /boot/EFI
+#arch-chroot mount /dev/${ROOTPART1} /boot/EFI
 #arch-chroot grub-install --target=x86_64-efi  --bootloader-id=grub_uefi --recheck
 #arch-chroot grub-mkconfig -o /boot/grub/grub.cfg

--- a/archinstall.sh
+++ b/archinstall.sh
@@ -2,10 +2,10 @@
 
 set -euxo pipefail
 
-HDD="/dev/nvme0n1"
-ROOTPART="/dev/nvme0n1p2"
-BOOTPART="/dev/nvme0n1p1"
-HOST="archbox"
+readonly HDD="/dev/nvme0n1"
+readonly ROOTPART="/dev/nvme0n1p2"
+readonly BOOTPART="/dev/nvme0n1p1"
+readonly HOST="archbox"
 
 
 # this script creats a fresh arch linux install

--- a/archinstall.sh
+++ b/archinstall.sh
@@ -1,4 +1,5 @@
-#/bin/bash
+#!/usr/bin/env bash
+
 HDD="/dev/nvme0n1"
 ROOTPART="/dev/nvme0n1p2"
 BOOTPART="/dev/nvme0n1p1"

--- a/archinstall.sh
+++ b/archinstall.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euxo pipefail
+
 HDD="/dev/nvme0n1"
 ROOTPART="/dev/nvme0n1p2"
 BOOTPART="/dev/nvme0n1p1"


### PR DESCRIPTION
This PR adds some shell best practices:

* Use more portable shebang
* Use recommended `set` safeguards
* Surround variables with `${}` to avoid errors
* Declare variables as constants